### PR TITLE
Change url from tilvids.com to blog.tilvids.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ google_analytics:
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed
-url: https://tilvids.com
+url: https://blog.tilvids.com
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)


### PR DESCRIPTION
RSS and Sitemap.xml need to have the correct URL set. Until now that was mistakenly tilvids.com but it should be blog.tilvids.com otherwise the links in the RSS feed will lead to a 404 on the PeerTube instance instead to the blog post.